### PR TITLE
Fix for facemesh canvas flip and scale bug

### DIFF
--- a/src/utilities.js
+++ b/src/utilities.js
@@ -71,6 +71,9 @@ const eyePoints = [
 export const drawFace = (predictions, canvas) => {
   const ctx = canvas.getContext("2d");
   ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.translate(canvas.width,0)
+  ctx.scale(-1,1)
+  
   ctx.font = "14px serif";
   ctx.fillStyle = "white";
   if (predictions.length > 0) {
@@ -87,7 +90,7 @@ export const drawFace = (predictions, canvas) => {
       // Draw facial keypoints.
       for (let j = 0; j < keypoints.length; j += 1) {
         const [x, y] = keypoints[j];
-        ctx.fillText("·", x, y);
+        ctx.fillText("·", x*1.25, y*1.25);
       }
     }
 
@@ -105,6 +108,7 @@ export const drawFace = (predictions, canvas) => {
       }
     });
   }
+  ctx.resetTransform()
 };
 function getEAR(upper, lower) {
   return (


### PR DESCRIPTION
It was weird indeed! I added some workarounds.

I flipped the drawing context with translate and scale(-1,1), and added the reset transform back to normal coordinates for the other model as that one is flipping correctly.

For the offset, it seems that facemesh returns by default 640x480 coordinates, ignoring the canvas dimensions, I added a 1.25 factor to make it 800x600 (800/640 = 1.25)